### PR TITLE
feat: use ObsClientProvider in dataplane

### DIFF
--- a/extensions/common/obs/obs-core/src/main/java/com/huawei/cloud/obs/ObsClientProvider.java
+++ b/extensions/common/obs/obs-core/src/main/java/com/huawei/cloud/obs/ObsClientProvider.java
@@ -1,6 +1,7 @@
 package com.huawei.cloud.obs;
 
 import com.huaweicloud.sdk.iam.v3.IamClient;
+import com.obs.services.IObsCredentialsProvider;
 import com.obs.services.ObsClient;
 import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 
@@ -8,9 +9,18 @@ import org.eclipse.edc.runtime.metamodel.annotation.ExtensionPoint;
 public interface ObsClientProvider {
 
     /**
-     * Returns the client for the specified endpoint
+     * Returns the client for the specified endpoint, using a global configuration
      */
     ObsClient obsClient(String endpoint);
+
+    /**
+     * Returns the client for the specified endpoint, but using the given credentials provider
+     *
+     * @param endpoint            The OBS endpoint to connect to
+     * @param credentialsProvider The credentials provider for authentication
+     * @return The ObsClient instance
+     */
+    ObsClient obsClient(String endpoint, IObsCredentialsProvider credentialsProvider);
 
     /**
      * Returns the iam client

--- a/extensions/common/obs/obs-core/src/main/java/com/huawei/cloud/obs/ObsClientProviderImpl.java
+++ b/extensions/common/obs/obs-core/src/main/java/com/huawei/cloud/obs/ObsClientProviderImpl.java
@@ -7,6 +7,7 @@ import com.obs.services.OBSCredentialsProviderChain;
 import com.obs.services.ObsClient;
 import com.obs.services.ObsConfiguration;
 import org.eclipse.edc.spi.monitor.Monitor;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -29,9 +30,23 @@ public class ObsClientProviderImpl implements ObsClientProvider {
         this.monitor = monitor;
     }
 
+    @NotNull
+    private static ObsConfiguration createObsConfiguration(String endpoint) {
+        var config = new ObsConfiguration();
+        config.setPathStyle(true); //otherwise the bucketname gets prepended
+        config.setEndPoint(endpoint);
+        return config;
+    }
+
     @Override
     public ObsClient obsClient(String endpoint) {
         return clients.computeIfAbsent(endpoint, this::createClient);
+    }
+
+    @Override
+    public ObsClient obsClient(String endpoint, IObsCredentialsProvider credentialsProvider) {
+        var config = createObsConfiguration(endpoint);
+        return new ObsClient(credentialsProvider, config);
     }
 
     @Override
@@ -50,9 +65,7 @@ public class ObsClientProviderImpl implements ObsClientProvider {
     }
 
     private ObsClient createClient(String endpoint) {
-        var config = new ObsConfiguration();
-        config.setPathStyle(true); //otherwise the bucketname gets prepended
-        config.setEndPoint(endpoint);
+        var config = createObsConfiguration(endpoint);
         return new ObsClient(configuration.getCredentialsProvider(), config);
     }
 

--- a/extensions/data-plane/data-plane-obs/src/main/java/com/huawei/cloud/transfer/obs/ObsDataSinkFactory.java
+++ b/extensions/data-plane/data-plane-obs/src/main/java/com/huawei/cloud/transfer/obs/ObsDataSinkFactory.java
@@ -1,6 +1,7 @@
 package com.huawei.cloud.transfer.obs;
 
 import com.huawei.cloud.obs.ObsBucketSchema;
+import com.huawei.cloud.obs.ObsClientProvider;
 import com.huawei.cloud.transfer.obs.validation.ObsDataAddressValidationRule;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSink;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSinkFactory;
@@ -23,8 +24,8 @@ public class ObsDataSinkFactory extends ObsFactory implements DataSinkFactory {
     private final Monitor monitor;
     private final ExecutorService executorService;
 
-    public ObsDataSinkFactory(Vault vault, TypeManager typeManager, Monitor monitor, ExecutorService executorService) {
-        super(vault, typeManager);
+    public ObsDataSinkFactory(Vault vault, TypeManager typeManager, Monitor monitor, ExecutorService executorService, ObsClientProvider clientProvider) {
+        super(vault, typeManager, clientProvider);
         this.monitor = monitor;
         this.executorService = executorService;
     }

--- a/extensions/data-plane/data-plane-obs/src/main/java/com/huawei/cloud/transfer/obs/ObsDataSourceFactory.java
+++ b/extensions/data-plane/data-plane-obs/src/main/java/com/huawei/cloud/transfer/obs/ObsDataSourceFactory.java
@@ -1,6 +1,7 @@
 package com.huawei.cloud.transfer.obs;
 
 import com.huawei.cloud.obs.ObsBucketSchema;
+import com.huawei.cloud.obs.ObsClientProvider;
 import com.huawei.cloud.transfer.obs.validation.ObsDataAddressValidationRule;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSource;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.DataSourceFactory;
@@ -20,8 +21,8 @@ public class ObsDataSourceFactory extends ObsFactory implements DataSourceFactor
 
     private final ValidationRule<DataAddress> validation = new ObsDataAddressValidationRule();
 
-    public ObsDataSourceFactory(Vault vault, TypeManager typeManager) {
-        super(vault, typeManager);
+    public ObsDataSourceFactory(Vault vault, TypeManager typeManager, ObsClientProvider clientProvider) {
+        super(vault, typeManager, clientProvider);
     }
 
     @Override

--- a/extensions/data-plane/data-plane-obs/src/main/java/com/huawei/cloud/transfer/obs/ObsTransferExtension.java
+++ b/extensions/data-plane/data-plane-obs/src/main/java/com/huawei/cloud/transfer/obs/ObsTransferExtension.java
@@ -1,5 +1,6 @@
 package com.huawei.cloud.transfer.obs;
 
+import com.huawei.cloud.obs.ObsClientProvider;
 import org.eclipse.edc.connector.dataplane.spi.pipeline.PipelineService;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Inject;
@@ -21,15 +22,17 @@ public class ObsTransferExtension implements ServiceExtension {
     private TypeManager typeManager;
     @Inject
     private Vault vault;
+    @Inject
+    private ObsClientProvider clientProvider;
 
     @Override
     public void initialize(ServiceExtensionContext context) {
 
-        var sourceFactory = new ObsDataSourceFactory(vault, typeManager);
+        var sourceFactory = new ObsDataSourceFactory(vault, typeManager, clientProvider);
         pipelineService.registerFactory(sourceFactory);
 
         var executor = Executors.newFixedThreadPool(10);
-        var sinkFactory = new ObsDataSinkFactory(vault, typeManager, context.getMonitor(), executor);
+        var sinkFactory = new ObsDataSinkFactory(vault, typeManager, context.getMonitor(), executor, clientProvider);
         pipelineService.registerFactory(sinkFactory);
     }
 

--- a/extensions/data-plane/data-plane-obs/src/test/java/com/huawei/cloud/transfer/obs/ObsDataSinkFactoryTest.java
+++ b/extensions/data-plane/data-plane-obs/src/test/java/com/huawei/cloud/transfer/obs/ObsDataSinkFactoryTest.java
@@ -1,6 +1,7 @@
 package com.huawei.cloud.transfer.obs;
 
 import com.huawei.cloud.obs.ObsBucketSchema;
+import com.huawei.cloud.obs.ObsClientProvider;
 import org.eclipse.edc.junit.assertions.AbstractResultAssert;
 import org.eclipse.edc.spi.EdcException;
 import org.eclipse.edc.spi.security.Vault;
@@ -19,6 +20,8 @@ import static com.huawei.cloud.obs.TestFunctions.dataAddressWithCredentials;
 import static com.huawei.cloud.obs.TestFunctions.dataAddressWithoutCredentials;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -28,10 +31,12 @@ class ObsDataSinkFactoryTest {
 
     private final Vault vaultMock = mock();
     private final ExecutorService executor = Executors.newFixedThreadPool(1);
-    private final ObsDataSinkFactory factory = new ObsDataSinkFactory(vaultMock, new TypeManager(), mock(), executor);
+    private final ObsClientProvider obsClientProviderMock = mock();
+    private final ObsDataSinkFactory factory = new ObsDataSinkFactory(vaultMock, new TypeManager(), mock(), executor, obsClientProviderMock);
 
     @BeforeEach
     void setUp() {
+        when(obsClientProviderMock.obsClient(anyString(), any())).thenReturn(mock());
     }
 
     @Test

--- a/extensions/data-plane/data-plane-obs/src/test/java/com/huawei/cloud/transfer/obs/ObsDataSourceFactoryTest.java
+++ b/extensions/data-plane/data-plane-obs/src/test/java/com/huawei/cloud/transfer/obs/ObsDataSourceFactoryTest.java
@@ -1,6 +1,7 @@
 package com.huawei.cloud.transfer.obs;
 
 import com.huawei.cloud.obs.ObsBucketSchema;
+import com.huawei.cloud.obs.ObsClientProvider;
 import org.eclipse.edc.spi.security.Vault;
 import org.eclipse.edc.spi.types.TypeManager;
 import org.eclipse.edc.spi.types.domain.DataAddress;
@@ -24,15 +25,18 @@ import static com.huawei.cloud.obs.TestFunctions.dataAddressWithCredentials;
 import static com.huawei.cloud.obs.TestFunctions.dataAddressWithoutCredentials;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ObsDataSourceFactoryTest {
+    public static final ObsClientProvider CLIENT_PROVIDER = mock();
     private final TypeManager typeManager = new TypeManager();
     private final Vault vault = mock(Vault.class);
-    private final ObsDataSourceFactory factory = new ObsDataSourceFactory(vault, typeManager);
+    private final ObsDataSourceFactory factory = new ObsDataSourceFactory(vault, typeManager, CLIENT_PROVIDER);
 
     @Test
     void canHandle() {
@@ -125,7 +129,8 @@ class ObsDataSourceFactoryTest {
     void createSource_noCredentials_shouldFail() {
         var source = dataAddressWithoutCredentials();
         var req = createRequest(source);
-        assertThatThrownBy(() -> factory.createSource(req)).isInstanceOf(IllegalArgumentException.class).hasMessageEndingWith("access key should not be null or empty.");
+        when(CLIENT_PROVIDER.obsClient(anyString(), any())).thenThrow(IllegalArgumentException.class);
+        assertThatThrownBy(() -> factory.createSource(req)).isInstanceOf(IllegalArgumentException.class);
     }
 
     private DataFlowRequest createRequest(DataAddress source) {


### PR DESCRIPTION
Use the `ObsClientProvider` in the data plane, i.e. in the sink/source factories
