### PR TITLE
feat: run gaussdb tests nightly

### DIFF
--- a/.github/workflows/gaussdb-tests.yaml
+++ b/.github/workflows/gaussdb-tests.yaml
@@ -1,0 +1,62 @@
+---
+name: "Run GaussDB Tests"
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  secret-presence:
+    runs-on: ubuntu-latest
+    outputs:
+      HAS_CLOUD_CRED: ${{ steps.secret-presence.outputs.HAS_CLOUD_CRED }}
+    steps:
+      - name: Check whether secrets exist
+        id: secret-presence
+        run: |
+          [ ! -z "${{ secrets.access_key }}" ] && 
+          [ ! -z "${{ secrets.secret_key }}" ] && echo "HAS_CLOUD_CRED=true" >> $GITHUB_OUTPUT
+          exit 0
+  
+
+  provision-gaussdb:
+    runs-on: ubuntu-latest
+    needs: [ secret-presence ]
+    if: |
+      needs.secret-presence.outputs.HAS_CLOUD_CRED
+    env:
+      HW_ACCESS_KEY: ${{ secrets.access_key }}
+      HW_SECRET_KEY: ${{ secrets.secret_key }}
+
+    steps:
+      - uses: actions/checkout@4
+
+      - name: "Terraform init"
+        working-directory: ./deployment
+        run: |-
+          terraform init -reconfigure
+      - name: "Terraform plan"
+        working-directory: ./deployment
+        run: |-
+          terraform plan -out=$GITHUB_SHA.out
+
+      - name: "Terraform apply"
+        working-directory: ./deployment
+        run: |-
+          terraform apply "$GITHUB_SHA.out"
+
+      - name: "Store PG connection string as env"
+        working-directory: ./deployment
+        run: |-
+          echo "PG_CONNECTION_STRING=$(terraform output -raw pg_connection_string)" >> $GITHUB_ENV
+
+      - name: "Echo Connection String"
+        run: |-
+          echo $PG_CONNECTION_STRING
+
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-java
+      - name: GaussDB Integration Tests
+        run: |
+          ./gradlew compileJava compileTestJava
+          ./gradlew test -DincludeTags="GaussDbTest" -PverboseTest=true --no-parallel

--- a/.github/workflows/gaussdb-tests.yaml
+++ b/.github/workflows/gaussdb-tests.yaml
@@ -19,7 +19,7 @@ jobs:
           exit 0
   
 
-  provision-gaussdb:
+  run-gaussdb-tests:
     runs-on: ubuntu-latest
     needs: [ secret-presence ]
     if: |
@@ -56,7 +56,13 @@ jobs:
 
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-java
-      - name: GaussDB Integration Tests
+      - name: "GaussDB Integration Tests"
+        continue-on-error: true
         run: |
           ./gradlew compileJava compileTestJava
           ./gradlew test -DincludeTags="GaussDbTest" -PverboseTest=true --no-parallel
+
+      - name: "Terraform destroy"
+        run: |-
+          terraform plan -destroy -out=$GITHUB_SHA.out
+          terraform apply "$GITHUB_SHA.out"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -47,17 +47,3 @@ jobs:
           ./gradlew compileJava compileTestJava
           ./gradlew test -DincludeTags="OtcTest" -PverboseTest=true
 
-  gaussdb-test:
-    runs-on: ubuntu-latest
-    needs: [ secret-presence ]
-    if: |
-      needs.secret-presence.outputs.HAS_PG_CONNECTION_STRING
-    env:
-      PG_CONNECTION_STRING: ${{ secrets.pg_connection_string }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-java
-      - name: GaussDB Integration Tests
-        run: |
-          ./gradlew compileJava compileTestJava
-          ./gradlew test -DincludeTags="GaussDbTest" -PverboseTest=true --no-parallel

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ build
 .idea/
 out/
 build/
+
+# Ignore terraform stuff
+.terraform
+*.tfstate.backup
+.terraform.lock.hcl
+*.tfstate

--- a/deployment/gaussdb.tf
+++ b/deployment/gaussdb.tf
@@ -1,0 +1,52 @@
+data "huaweicloud_availability_zones" "test" {
+}
+
+resource "huaweicloud_gaussdb_opengauss_instance" "instance_acc" {
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_network_id
+  security_group_id = var.security_group_id
+  name              = var.instance_name
+  password          = var.instance_password
+  flavor            = "gaussdb.opengauss.ee.m6.2xlarge.x868.ha"
+  availability_zone = join(",", slice(data.huaweicloud_availability_zones.test.names, 0, 3))
+
+  replica_num  = 3
+  sharding_num = 1
+
+  ha {
+    mode             = "centralization_standard"
+    replication_mode = "sync"
+    consistency      = "eventual"
+  }
+
+  volume {
+    type = "ULTRAHIGH"
+    size = 40
+  }
+}
+
+
+resource "huaweicloud_vpc_bandwidth" "gaussdb-bw-shared" {
+  name = var.bandwidth_name
+  size = 5
+}
+
+resource "huaweicloud_vpc_eip" "shared" {
+  publicip {
+    # can be 5_bgp (dynamic BGP) and 5_sbgp (static BGP)
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    # WHOLE means shared bandwidth
+    share_type = "WHOLE"
+    id         = huaweicloud_vpc_bandwidth.gaussdb-bw-shared.id
+  }
+}
+
+
+resource "huaweicloud_vpc_eip_associate" "associated" {
+  public_ip  = huaweicloud_vpc_eip.shared.address
+  network_id = var.subnet_network_id
+  fixed_ip   = huaweicloud_gaussdb_opengauss_instance.instance_acc.private_ips[0]
+}

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    huaweicloud = {
+      source  = "huaweicloud/huaweicloud"
+      version = "1.57.0"
+    }
+  }
+}
+
+provider "huaweicloud" {
+  region = var.region
+}

--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -1,0 +1,8 @@
+output "database-ip" {
+  value = huaweicloud_vpc_eip.shared.address
+}
+
+# this is needed by the CI job to obtain the PG Connection String
+output "pg_connection_string" {
+  value = "jdbc:gaussdb://${huaweicloud_vpc_eip.shared.address}:8000/postgres?user=root&password=${var.instance_password}&sslMode=require"
+}

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -1,0 +1,27 @@
+variable "region" {
+  default = "ap-southeast-1"
+}
+
+variable "instance_name" {
+  default = "gaussdb-paul"
+}
+variable "instance_password" {
+  default = "dJyqo4vLoL!DGFZRLPVu*DbX"
+}
+# this is the ID for the "vpc-default" VPC
+variable "vpc_id" {
+  default = "08ebdc09-de15-4c41-91cf-db1cca8c1033"
+}
+# this is the ID for the "subnet-default"
+variable "subnet_network_id" {
+  default = "c9a10db0-1fe9-4863-a740-3cd342e8b909"
+}
+# this is the ID for the "default" security group
+variable "security_group_id" {
+  default = "0599125e-1015-4628-8775-9187fd0e60e7"
+}
+
+# name of the bandwidth resources
+variable "bandwidth_name" {
+  default = "test-gaussdb-bandwidth"
+}


### PR DESCRIPTION
This PR adds terraform scripts to provision a GaussDB cluster, and adds a 
CI workflow to execute it, then run the tests, and tear it down again.
